### PR TITLE
Support syntax highlighting for julia

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,18 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "grammars": [
+      {
+        "path": "./syntaxes/julia_codeblock.json",
+        "scopeName": "markdown.julia.codebraid",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.julia": "julia"
+        }
+      }
+    ],
     "commands": [
       {
         "command": "codebraidPreview.startPreview",

--- a/syntaxes/julia_codeblock.json
+++ b/syntaxes/julia_codeblock.json
@@ -1,0 +1,45 @@
+{
+    "scopeName": "markdown.julia.codebraid",
+    "fileTypes": [],
+    "injectionSelector": "L:text.html.markdown",
+    "patterns": [
+        {
+            "include": "#fenced_codebraid_julia"
+        }
+    ],
+    "repository": {
+        "fenced_codebraid_julia": {
+            "begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(\\{\\.julia.*\\})((\\s+|:|\\{)[^`~]*)?$)",
+            "name": "markup.fenced_code.block.markdown",
+            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "beginCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                },
+                "4": {
+                    "name": "fenced_code.block.language"
+                },
+                "5": {
+                    "name": "fenced_code.block.language.attributes"
+                }
+            },
+            "endCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                }
+            },
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.julia",
+                    "patterns": [
+                        {
+                            "include": "source.julia"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/test.md
+++ b/test.md
@@ -1,0 +1,7 @@
+# This is a test of code braid
+
+```{.julia}
+if x > 2 
+    error("I am too LARGE!!")
+end
+```

--- a/test.md
+++ b/test.md
@@ -1,7 +1,0 @@
-# This is a test of code braid
-
-```{.julia}
-if x > 2 
-    error("I am too LARGE!!")
-end
-```


### PR DESCRIPTION
This adds support for highlighting julia code in Markdown files intended for codebraid. 

I'm guessing this might also be useful for other langauges, but I know at least python already works, and I haven't tested the other options.